### PR TITLE
fix import pip version 10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
-from pip.req import parse_requirements as parse
+try:
+    from pip._internal.req import parse_requirements as parse
+except ImportError:
+    from pip.req import parse_requirements as parse
 
 requirements = lambda f: [str(i.req) for i in parse(f, session=False)]
 


### PR DESCRIPTION
```
pip3 install https://github.com/leotada/PyNFe/archive/master.zip
Collecting https://github.com/leotada/PyNFe/archive/master.zip
  Downloading https://github.com/leotada/PyNFe/archive/master.zip (4.7MB)
    100% |████████████████████████████████| 4.7MB 272kB/s 
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-ij8_n6r6/setup.py", line 3, in <module>
        from pip.req import parse_requirements as parse
    ModuleNotFoundError: No module named 'pip.req'
```
    
